### PR TITLE
Update puppetlabs.pp

### DIFF
--- a/manifests/puppetlabs.pp
+++ b/manifests/puppetlabs.pp
@@ -55,7 +55,7 @@ class postgres_hardening::puppetlabs(
       require => Class['postgresql::server::install'],
     }
 
-    file { "/var/lib/postgresql/${postgresql::server::version}":
+    file { '/var/lib/postgresql/${postgresql::server::version}':
       ensure  => 'directory',
       mode    => '0700',
       require => Class['postgresql::server::install'],


### PR DESCRIPTION
When the file command in line 58 used double quotes running puppet agent --test fails on Ubuntu 16.04. Changing it to single quotes resolved the issue.

nkane@postgresql:~$ sudo /opt/puppetlabs/bin/puppet agent --test
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Cannot alias File[/var/lib/postgresql/] to ["/var/lib/postgresql"] at /etc/puppetlabs/code/environments/production/modules/postgres_hardening/manifests/puppetlabs.pp:58; resource ["File", "/var/lib/postgresql"] already declared at /etc/puppetlabs/code/environments/production/modules/postgres_hardening/manifests/puppetlabs.pp:52 at /etc/puppetlabs/code/environments/production/modules/postgres_hardening/manifests/puppetlabs.pp:58:5 on node postgresql.silentkane.tech
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
nkane@postgresql:~$ sudo /opt/puppetlabs/bin/puppet agent --test
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for postgresql.silentkane.tech
Info: Applying configuration version '1512276398'
Notice: /Stage[main]/Postgres_hardening::Puppetlabs/File[/var/lib/postgresql/${postgresql::server::version}]/ensure: created
Notice: Applied catalog in 0.28 seconds